### PR TITLE
Replace activate event listener with onfocus

### DIFF
--- a/PiPifier-Safari-Extension/SafariExtensionHandler.swift
+++ b/PiPifier-Safari-Extension/SafariExtensionHandler.swift
@@ -9,7 +9,7 @@
 import SafariServices
 
 enum Message: String {
-	case videoCheck, addCustomPiPButtonsIfNeeded
+	case videoCheck, checkIfPiPEnabled
 }
 
 class SafariExtensionHandler: SFSafariExtensionHandler {
@@ -25,8 +25,8 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 			NSLog("INFO: videoCheck: \(userInfo?["found"] as? Bool ?? false)")
 			StateManager.shared.videosFound[page] = userInfo?["found"] as? Bool ?? false
 			SFSafariApplication.setToolbarItemsNeedUpdate()
-        case .addCustomPiPButtonsIfNeeded:
-            addCustomPiPButtonsIfNeeded()
+        case .checkIfPiPEnabled:
+            checkIfPiPEnabled(callback: userInfo?["callback"] as? String)
 		}
 	}
 	
@@ -41,6 +41,8 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     override func validateToolbarItem(in window: SFSafariWindow, validationHandler: @escaping (Bool, String) -> Void) {
 		getActivePage {
 			guard let page = $0 else {return}
+			NSLog("INFO: videosFound: \(StateManager.shared.videosFound)")
+			NSLog("INFO: video found: \(StateManager.shared.videosFound[page])")
 			let videoFound = StateManager.shared.videosFound[page] ?? false
 			NSLog("INFO: validating toolbarItem: \(videoFound)")
 			validationHandler(videoFound, "")
@@ -53,10 +55,10 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     
     //MARK: - customPiPButton methods
     
-    func addCustomPiPButtonsIfNeeded() {
-		guard SettingsManager.shared.isCustomPiPButtonsEnabled else {return}
+	func checkIfPiPEnabled(callback: String?) {
+		guard let callback = callback, SettingsManager.shared.isCustomPiPButtonsEnabled else {return}
 		getActivePage {
-			$0?.dispatchMessageToScript(withName: "addCustomPiPButtons", userInfo: nil)
+			$0?.dispatchMessageToScript(withName: "addCustomPiPButtonToPlayer", userInfo: ["callback": callback])
 		}
     }
 	

--- a/PiPifier-Safari-Extension/SafariExtensionHandler.swift
+++ b/PiPifier-Safari-Extension/SafariExtensionHandler.swift
@@ -20,7 +20,6 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 			return
 		}
 		NSLog("INFO: recieved message: \(message)")
-		guard userInfo?["iframe"] as? Bool != true else {return}
 		switch message {
 		case .videoCheck:
 			NSLog("INFO: videoCheck: \(userInfo?["found"] as? Bool ?? false)")

--- a/PiPifier-Safari-Extension/SafariExtensionHandler.swift
+++ b/PiPifier-Safari-Extension/SafariExtensionHandler.swift
@@ -9,7 +9,7 @@
 import SafariServices
 
 enum Message: String {
-	case videoCheck, checkIfPiPEnabled
+	case videoCheck, pipCheck
 }
 
 class SafariExtensionHandler: SFSafariExtensionHandler {
@@ -25,8 +25,8 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 			NSLog("INFO: videoCheck: \(userInfo?["found"] as? Bool ?? false)")
 			StateManager.shared.videosFound[page] = userInfo?["found"] as? Bool ?? false
 			SFSafariApplication.setToolbarItemsNeedUpdate()
-        case .checkIfPiPEnabled:
-            checkIfPiPEnabled(callback: userInfo?["callback"] as? String)
+        case .pipCheck:
+            pipCheck(callback: userInfo?["callback"])
 		}
 	}
 	
@@ -55,7 +55,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     
     //MARK: - customPiPButton methods
     
-	func checkIfPiPEnabled(callback: String?) {
+	func pipCheck(callback: Any?) {
 		guard let callback = callback, SettingsManager.shared.isCustomPiPButtonsEnabled else {return}
 		getActivePage {
 			$0?.dispatchMessageToScript(withName: "addCustomPiPButtonToPlayer", userInfo: ["callback": callback])

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -26,26 +26,16 @@ function messageHandler(event) {
     }
 }
 
-var firstCheck = true;
-var previousResult = false;
-
 
 function checkForVideo() {
 	if (getVideo() != null) {
-		if (!previousResult) {
-			previousResult = true;
-			console.log("Found a video");
-            shouldCustomPiPButtonsBeAdded();
-			dispatchMessage("videoFound");
-		}
+		console.log("Found a video");
+        shouldCustomPiPButtonsBeAdded();
+		dispatchMessage("videoFound");
 	} else if (window == window.top) {
-		if (previousResult || firstCheck) {
-			previousResult = false;
-			console.log("Found no video on top");
-			dispatchMessage("noVideoFound");
-		}
+		console.log("Found no video on top");
+		dispatchMessage("noVideoFound");
 	}
-	firstCheck = false;
 }
 
 function getVideo() {

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -7,8 +7,8 @@ var whiteSVG_Icon = safari.extension.baseURI + 'PiP_Toolbar_Icon_white.svg'
 var blackSVG_Icon = safari.extension.baseURI + 'PiP_Toolbar_Icon.svg'
 
 safari.self.addEventListener("message", messageHandler); // Message recieved from Swift code
-safari.self.addEventListener("activate", checkForVideo); // Tab changed
-new MutationObserver(checkForVideo).observe(document, {subtree: true, childList: true}); // DOM changed
+window.onfocus = function() {checkForVideo(true)}
+new MutationObserver(function() {checkForVideo(false)}).observe(document, {subtree: true, childList: true}); // DOM changed
 
 
 
@@ -26,15 +26,22 @@ function messageHandler(event) {
     }
 }
 
+var previousResult = false;
 
-function checkForVideo() {
+function checkForVideo(force) {
 	if (getVideo() != null) {
-		console.log("Found a video");
-        shouldCustomPiPButtonsBeAdded();
-		dispatchMessage("videoFound");
+		if (!previousResult || force) {
+			previousResult = true
+			console.log("Found a video");
+			shouldCustomPiPButtonsBeAdded();
+			dispatchMessage("videoFound");
+		}
 	} else if (window == window.top) {
-		console.log("Found no video on top");
-		dispatchMessage("noVideoFound");
+		if (previousResult || force) {
+			previousResult = false
+			console.log("Found no video on top");
+			dispatchMessage("noVideoFound");
+		}
 	}
 }
 

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -31,14 +31,14 @@ var previousResult = false;
 function checkForVideo(force) {
 	if (getVideo() != null) {
 		if (!previousResult || force) {
-			previousResult = true
+			previousResult = true;
 			console.log("Found a video");
 			shouldCustomPiPButtonsBeAdded();
 			dispatchMessage("videoFound");
 		}
 	} else if (window == window.top) {
 		if (previousResult || force) {
-			previousResult = false
+			previousResult = false;
 			console.log("Found no video on top");
 			dispatchMessage("noVideoFound");
 		}

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -25,11 +25,12 @@ function messageHandler(event) {
 }
 
 function checkForVideo() {
+	if (window != window.top) return;
 	if (getVideo() != null) {
 		console.log("Found a video");
 		shouldCustomPiPButtonsBeAdded();
 		dispatchMessage("videoFound");
-	} else if (window == window.top) {
+	} else {
 		console.log("Found no video on top");
 		dispatchMessage("noVideoFound");
 	}

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -7,10 +7,8 @@ var whiteSVG_Icon = safari.extension.baseURI + 'PiP_Toolbar_Icon_white.svg'
 var blackSVG_Icon = safari.extension.baseURI + 'PiP_Toolbar_Icon.svg'
 
 safari.self.addEventListener("message", messageHandler); // Message recieved from Swift code
-window.onfocus = function() {checkForVideo(true)}
-new MutationObserver(function() {checkForVideo(false)}).observe(document, {subtree: true, childList: true}); // DOM changed
-
-
+window.onfocus = checkForVideo // Tab selected
+new MutationObserver(checkForVideo).observe(document, {subtree: true, childList: true}); // DOM changed
 
 
 function dispatchMessage(messageName) {
@@ -26,22 +24,14 @@ function messageHandler(event) {
     }
 }
 
-var previousResult = false;
-
-function checkForVideo(force) {
+function checkForVideo() {
 	if (getVideo() != null) {
-		if (!previousResult || force) {
-			previousResult = true;
-			console.log("Found a video");
-			shouldCustomPiPButtonsBeAdded();
-			dispatchMessage("videoFound");
-		}
+		console.log("Found a video");
+		shouldCustomPiPButtonsBeAdded();
+		dispatchMessage("videoFound");
 	} else if (window == window.top) {
-		if (previousResult || force) {
-			previousResult = false;
-			console.log("Found no video on top");
-			dispatchMessage("noVideoFound");
-		}
+		console.log("Found no video on top");
+		dispatchMessage("noVideoFound");
 	}
 }
 

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -53,9 +53,9 @@ function enablePiP() {
 //----------------- Custom Button Methods -----------------
 
 var players = [
-	{name: "YouTube", shouldAddButton: shouldAddYouTubeButton, addButton: "addYouTubeButton"},
-	{name: "VideoJS", shouldAddButton: shouldAddVideoJSButton, addButton: "addVideoJSButton"},
-	{name: "Netflix", shouldAddButton: shouldAddNetflixButton, addButton: "addNetflixButton"},
+	{name: "YouTube", shouldAddButton: shouldAddYouTubeButton, addButton: addYouTubeButton},
+	{name: "VideoJS", shouldAddButton: shouldAddVideoJSButton, addButton: addVideoJSButton},
+	{name: "Netflix", shouldAddButton: shouldAddNetflixButton, addButton: addNetflixButton},
 	//TODO: add other players here
 ];
 
@@ -63,7 +63,7 @@ function addCustomPiPButtons() {
 	for (const player of players) {
 		if (player.shouldAddButton()) {
 			console.log("Adding button to player: " + player.name);
-			dispatchMessage("checkIfPiPEnabled", {callback: player.addButton}) //Sets the callback to the player's addButton
+			dispatchMessage("pipCheck", {callback: player.addButton.name}) //Sets the callback to the player's addButton
 		}
 	}
 }

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -53,13 +53,13 @@ function enablePiP() {
 var players = [
 	{name: "YouTube", shouldAddButton: shouldAddYouTubeButton, addButton: addYouTubeButton},
 	{name: "VideoJS", shouldAddButton: shouldAddVideoJSButton, addButton: addVideoJSButton},
-	{name: "Netflix", shouldAddButton: shouldAddNetflixButton, addButton: function() {addNetflixButton(0)}},
+	{name: "Netflix", shouldAddButton: shouldAddNetflixButton, addButton: addNetflixButton},
 	//TODO: add other players here
 ];
 
 function addCustomPiPButtons() {
 	for (const player of players) {
-		if (player.shouldAddButton() && document.getElementsByClassName('PiPifierButton').length == 0) {
+		if (player.shouldAddButton()) {
 			console.log("Adding button to player: " + player.name);
 			player.addButton();
 		}
@@ -70,7 +70,8 @@ function addCustomPiPButtons() {
 
 function shouldAddYouTubeButton() {
 	return location.hostname.match(/^(www\.)?youtube\.com$/)
-		&& document.getElementsByClassName("ytp-right-controls").length > 0;
+		&& document.getElementsByClassName("ytp-right-controls").length > 0
+		&& document.getElementsByClassName('PiPifierButton').length == 0;
 }
 		
 function addYouTubeButton() {
@@ -91,7 +92,8 @@ function addYouTubeButton() {
 
 
 function shouldAddVideoJSButton() {
-	return document.getElementsByClassName('vjs-control-bar').length > 0;
+	return document.getElementsByClassName('vjs-control-bar').length > 0
+		&& document.getElementsByClassName('PiPifierButton').length == 0;
 }
 
 function addVideoJSButton() {
@@ -110,10 +112,12 @@ function addVideoJSButton() {
 
 
 function shouldAddNetflixButton() {
-	return location.hostname.match('netflix');
+	return location.hostname.match('netflix')
+		&& document.getElementsByClassName('PiPifierButton').length == 0;
 }
 
 function addNetflixButton(timeOutCounter) {
+	if (timeOutCounter == null) timeOutCounter = 0;
 	var button = document.createElement("button");
 	button.className = "PiPifierButton";
 	button.title = "PiP (by PiPifier)";
@@ -134,7 +138,9 @@ function addNetflixButton(timeOutCounter) {
 		//this is needed because the div is sometimes not reachable on the first load
 		console.log("Timeout needed");
 		//also necessary to count up and stop at some time to avoid endless loop on main netflix page
-		setTimeout(function() {addNetflixPlayerButton(timeOutCounter+1);}, 3000);
+		setTimeout(function() {
+			if (shouldAddNetflixButton()) addNetflixButton(timeOutCounter+1);
+		}, 3000);
 		return;
 	}
 	playerStatusDiv.insertBefore(button, playerStatusDiv.firstChild);

--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -51,14 +51,15 @@ function enablePiP() {
 //----------------- Custom Button Methods -----------------
 
 var players = [
-	{name: "YouTube", shouldAddButton: shouldAddYouTubePiPButton, addButton: addYouTubePiPButton},
-	{name: "Netflix", shouldAddButton: shouldAddNetflixPiPButton, addButton: addNetflixPiPButton},
+	{name: "YouTube", shouldAddButton: shouldAddYouTubeButton, addButton: addYouTubeButton},
+	{name: "VideoJS", shouldAddButton: shouldAddVideoJSButton, addButton: addVideoJSButton},
+	{name: "Netflix", shouldAddButton: shouldAddNetflixButton, addButton: function() {addNetflixButton(0)}},
 	//TODO: add other players here
 ];
 
 function addCustomPiPButtons() {
 	for (const player of players) {
-		if (player.shouldAddButton()) {
+		if (player.shouldAddButton() && document.getElementsByClassName('PiPifierButton').length == 0) {
 			console.log("Adding button to player: " + player.name);
 			player.addButton();
 		}
@@ -67,13 +68,12 @@ function addCustomPiPButtons() {
 
 //----------------- Player Implementations -------------------------
 
-function shouldAddYouTubePiPButton() {
-	return location.hostname.match(/^(www\.)?youtube\.com|youtu\.be$/)
-		&& document.getElementsByClassName("ytp-right-controls").length > 0
-		&& document.getElementsByClassName('PiPifierButton').length == 0;
+function shouldAddYouTubeButton() {
+	return location.hostname.match(/^(www\.)?youtube\.com$/)
+		&& document.getElementsByClassName("ytp-right-controls").length > 0;
 }
 		
-function addYouTubePiPButton() {
+function addYouTubeButton() {
 	var button = document.createElement("button");
 	button.className = "ytp-button PiPifierButton";
 	button.title = "PiP (by PiPifier)";
@@ -90,11 +90,52 @@ function addYouTubePiPButton() {
 }
 
 
-function shouldAddNetflixPiPButton() {
-	//TODO: method stub
-	return false;
+function shouldAddVideoJSButton() {
+	return document.getElementsByClassName('vjs-control-bar').length > 0;
 }
 
-function addNetflixPiPButton() {
-	//TODO: method stub
+function addVideoJSButton() {
+	var button = document.createElement("button");
+	button.className = "PiPifierButton vjs-control vjs-button";
+	button.title = "PiP (by PiPifier)";
+	button.onclick = enablePiP;
+	var buttonImage = document.createElement("img");
+	buttonImage.src = whiteSVG_Icon;
+	buttonImage.width = 16;
+	buttonImage.height = 30;
+	button.appendChild(buttonImage);
+	var fullscreenButton = document.getElementsByClassName("vjs-fullscreen-control")[0];
+	fullscreenButton.parentNode.insertBefore(button, fullscreenButton);
+}
+
+
+function shouldAddNetflixButton() {
+	return location.hostname.match('netflix');
+}
+
+function addNetflixButton(timeOutCounter) {
+	var button = document.createElement("button");
+	button.className = "PiPifierButton";
+	button.title = "PiP (by PiPifier)";
+	button.onclick = enablePiP;
+	button.height = 27;
+	button.width = 24;
+	button.style.backgroundColor = "transparent";
+	button.style.border = "none";
+	button.style.height = "100%";
+	var buttonImage = document.createElement("img");
+	buttonImage.src = whiteSVG_Icon;
+	buttonImage.width = 15;
+	buttonImage.height = 27;
+	buttonImage.style.verticalAlign = "middle";
+	button.appendChild(buttonImage);
+	var playerStatusDiv = document.getElementsByClassName("player-status")[0];
+	if (playerStatusDiv == null && timeOutCounter < 3) {
+		//this is needed because the div is sometimes not reachable on the first load
+		console.log("Timeout needed");
+		//also necessary to count up and stop at some time to avoid endless loop on main netflix page
+		setTimeout(function() {addNetflixPlayerButton(timeOutCounter+1);}, 3000);
+		return;
+	}
+	playerStatusDiv.insertBefore(button, playerStatusDiv.firstChild);
 }

--- a/PiPifier/Base.lproj/Main.storyboard
+++ b/PiPifier/Base.lproj/Main.storyboard
@@ -212,7 +212,7 @@
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="customPiPButtonsButtonPressed:" target="XfG-lQ-9wD" id="19y-j1-htK"/>
+                                    <action selector="customPiPButtonsButtonPressed:" target="XfG-lQ-9wD" id="PQX-iK-0id"/>
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="alM-Rc-oOk">

--- a/PiPifier/SettingsManager.swift
+++ b/PiPifier/SettingsManager.swift
@@ -15,7 +15,7 @@ class SettingsManager {
 	
     //NOTE: replace with your own group identifier when developping for yourself
     //Don't forget to change it in the entitlements as well otherwise it can cause crashes
-    let sharedUserDefaults = UserDefaults(suiteName: "group.APPenzeller.PiPifier")!
+    let sharedUserDefaults = UserDefaults(suiteName: "AW9CBV6SY7.group.APPenzeller.PiPifier")!
 	
 	let buttonEnabledKey = "customPiPButtonsEnabled"
 	

--- a/PiPifier/SettingsManager.swift
+++ b/PiPifier/SettingsManager.swift
@@ -11,23 +11,20 @@ import Cocoa
 class SettingsManager {
     
     static let shared = SettingsManager()
-    
+	private init() {}
+	
     //NOTE: replace with your own group identifier when developping for yourself
     //Don't forget to change it in the entitlements as well otherwise it can cause crashes
     let sharedUserDefaults = UserDefaults(suiteName: "group.APPenzeller.PiPifier")!
-    
-    var isCustomPiPButtonsEnabled:Bool{
-        get{
-            if let theBool = self.sharedUserDefaults.value(forKey: "customPiPButtonsEnabled"){
-                return theBool as! Bool
-            }
-                //default value is on
-            else{
-                return true
-            }
+	
+	let buttonEnabledKey = "customPiPButtonsEnabled"
+	
+    var isCustomPiPButtonsEnabled: Bool {
+        get {
+            return sharedUserDefaults.value(forKey: buttonEnabledKey) as? Bool ?? true //default value is on
         }
-        set(value){
-            self.sharedUserDefaults.setValue(value, forKey: "customPiPButtonsEnabled")
+        set(value) {
+			sharedUserDefaults.set(value, forKey: buttonEnabledKey)
         }
     }
 }

--- a/PiPifier/SettingsManager.swift
+++ b/PiPifier/SettingsManager.swift
@@ -15,7 +15,7 @@ class SettingsManager {
 	
     //NOTE: replace with your own group identifier when developping for yourself
     //Don't forget to change it in the entitlements as well otherwise it can cause crashes
-    let sharedUserDefaults = UserDefaults(suiteName: "AW9CBV6SY7.group.APPenzeller.PiPifier")!
+    let sharedUserDefaults = UserDefaults(suiteName: "group.APPenzeller.PiPifier")!
 	
 	let buttonEnabledKey = "customPiPButtonsEnabled"
 	

--- a/PiPifier/ViewController.swift
+++ b/PiPifier/ViewController.swift
@@ -12,10 +12,8 @@ class ViewController: NSViewController {
     
     @IBOutlet weak var customPiPButtonsButton: NSButton!
     
-    @IBAction func customPiPButtonsButtonPressed(_ sender: AnyObject) {
-        let buttonState = (sender as! NSButton).state
-        SettingsManager.shared.isCustomPiPButtonsEnabled = buttonState == 1
-        
+    @IBAction func customPiPButtonsButtonPressed(_ sender: NSButton) {
+        SettingsManager.shared.isCustomPiPButtonsEnabled = sender.state == 1
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
For some reason, the `activate` event listener is not being called due to which the only way to validate the toolbar button when the tab is switched is via the MutationObserver. However, thanks to the checks that I had put in place earlier, the JS would not tell the Swift code to validate it since it had already told it to do so before.

I have fixed this by removing the check entirely, although you should revert this PR if you figure out how to make the `activate` event listener work.