### PR TITLE
added selector for hulu

### DIFF
--- a/PiPifier-Safari-Extension/script.js
+++ b/PiPifier-Safari-Extension/script.js
@@ -43,6 +43,9 @@ function checkForVideo() {
 }
 
 function getVideo() {
+	if (location.hostname === "www.hulu.com") {
+		return document.getElementById('content-video-player');
+	}
 	return document.getElementsByTagName('video')[0];
 }
 
@@ -76,7 +79,7 @@ function shouldAddYouTubeButton() {
 		|| document.getElementsByClassName("ytp-right-controls").length > 0)
 		&& document.getElementsByClassName('PiPifierButton').length == 0;
 }
-		
+
 function addYouTubeButton() {
 	if (!shouldAddYouTubeButton()) return;
 	var button = document.createElement("button");
@@ -90,7 +93,7 @@ function addYouTubeButton() {
 	buttonImage.width = 22;
 	buttonImage.height = 36;
 	button.appendChild(buttonImage);
-	
+
 	document.getElementsByClassName("ytp-right-controls")[0].appendChild(button);
 }
 


### PR DESCRIPTION
Hey, man. _Love_ the extension. I don't have a developer account, so I wasn't able to test it on my machine, but I think it should let the extension button work (or at least be close) for Hulu. They have three video tags on the page, so this just grabs the one with the actual content. I plan on getting a developer account in the future, so I hope to keep collaborating on this soon. Let me know what you think.